### PR TITLE
Fix trainer info in race display

### DIFF
--- a/tests/test_display_races_and_horses.py
+++ b/tests/test_display_races_and_horses.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+requests_stub = types.ModuleType("requests")
+adapters_stub = types.ModuleType("requests.adapters")
+
+class HTTPAdapter:  # minimal stub for import
+    pass
+
+
+class Session:  # minimal stub for import
+    def mount(self, *args, **kwargs):
+        pass
+
+
+requests_stub.Session = Session
+adapters_stub.HTTPAdapter = HTTPAdapter
+requests_stub.adapters = adapters_stub
+sys.modules["requests"] = requests_stub
+sys.modules["requests.adapters"] = adapters_stub
+
+from v75 import display_races_and_horses
+
+
+def test_display_races_and_horses_includes_trainer(capsys):
+    races = [
+        {
+            "scheduledStartTime": "2023-01-01T12:00:00",
+            "id": "race1",
+            "number": 1,
+            "name": "Test Race",
+            "starts": [
+                {
+                    "number": 1,
+                    "horse": {
+                        "name": "Speedster",
+                        "id": 1,
+                        "pedigree": {"father": {"nationality": "US"}},
+                    },
+                    "driver": {"firstName": "John", "lastName": "Doe"},
+                    "trainer": {"firstName": "Jane", "lastName": "Smith"},
+                }
+            ],
+        }
+    ]
+
+    display_races_and_horses(races)
+    captured = capsys.readouterr()
+    assert "Trainer: Jane Smith" in captured.out

--- a/v75.py
+++ b/v75.py
@@ -113,6 +113,7 @@ def display_races_and_horses(races):
         for start in race.get("starts", []):
             horse = start["horse"]
             driver = start.get("driver", {})
+            trainer = start.get("trainer", {})
             horse_name = horse.get("name", "Unknown")
             horse_id = horse.get("id")
 
@@ -126,11 +127,12 @@ def display_races_and_horses(races):
 
             driver_first_name = driver.get("firstName", "Unknown")
             driver_last_name = driver.get("lastName", "Unknown")
-            trainer_last_name = driver.get("lastName", "Unknown")
+            trainer_first_name = trainer.get("firstName", "Unknown")
+            trainer_last_name = trainer.get("lastName", "Unknown")
             earnings = horse.get("money", "N/A")
 
             print(
-                f"{start['number']}. {horse_name} ({horse_nationality}) - Trainer: {trainer_last_name}, Driver: {driver_first_name} {driver_last_name}, Earnings: {earnings} SEK"
+                f"{start['number']}. {horse_name} ({horse_nationality}) - Trainer: {trainer_first_name} {trainer_last_name}, Driver: {driver_first_name} {driver_last_name}, Earnings: {earnings} SEK"
             )
 
 


### PR DESCRIPTION
## Summary
- Fix display_races_and_horses to show trainer name instead of driver
- Add test verifying trainer name output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961dcd138c83269ad969c07ac212bd